### PR TITLE
Add --dry-run flag to merge, deploy, and clone commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ optional arguments:
 $ sigsci_site_manager deploy --help
 usage: sigsci_site_manager deploy [-h] --name NAME
                                   [--display-name "Display Name"] --file
-                                  FILENAME
+                                  FILENAME [--dry-run]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -78,13 +78,14 @@ optional arguments:
                         Display name of the site
   --file FILENAME, -f FILENAME
                         Name of site file
+  --dry-run             Print actions without making any changes
 ```
 
 ### Clone Command
 ```shell
 $ sigsci_site_manager clone --help
 usage: sigsci_site_manager clone [-h] --src SITE --dest SITE
-                                 [--display-name "Display Name"]
+                                 [--display-name "Display Name"] [--dry-run]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -92,13 +93,14 @@ optional arguments:
   --dest SITE, -d SITE  Site to clone to
   --display-name "Display Name", -N "Display Name"
                         Display name of the new site
+  --dry-run             Print actions without making any changes
 ```
 
 ### Merge Command
 ```shell
 $ sigsci_site_manager merge --help
 usage: sigsci_site_manager merge [-h] --dest SITE
-                                 [--src SITE | --file FILENAME]
+                                 [--src SITE | --file FILENAME] [--dry-run]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -106,4 +108,5 @@ optional arguments:
   --src SITE, -s SITE   Site to merge from
   --file FILENAME, -f FILENAME
                         Name of site file to merge from
+  --dry-run             Print actions without making any changes
 ```

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         'pytest-runner'
     ],
     install_requires=[
-        'pysigsci>=2.0.3'
+        'pysigsci>=2.0.5'
     ],
     tests_require=[
         'pytest'

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         'pytest-runner'
     ],
     install_requires=[
-        'pysigsci>=2.0.5'
+        'pysigsci>=2.0.7'
     ],
     tests_require=[
         'pytest'

--- a/sigsci_site_manager/api.py
+++ b/sigsci_site_manager/api.py
@@ -1,8 +1,29 @@
 from pysigsci import sigsciapi
 
 
-def init_api(username, password, token, corp):
+def noop(*args, **kwargs):
+    return
+
+
+def init_api(username, password, token, corp, dry_run=False):
     api = sigsciapi.SigSciApi(
         email=username, password=password, api_token=token)
     api.corp = corp
+
+    if dry_run:
+        # When doing a dry run override the API methods that make changes so
+        # that they do nothing. Still need the methods that get things to
+        # work so that changes can be determined.
+        print('Dry run...')
+        api.create_corp_site = noop
+        api.add_rule_lists = noop
+        api.add_custom_signals = noop
+        api.add_request_rules = noop
+        api.add_signal_rules = noop
+        api.add_templated_rules = noop
+        api.add_custom_alert = noop
+        api.update_rule_lists = noop
+        api.update_custom_alert = noop
+        api.update_site_member = noop
+
     return api

--- a/sigsci_site_manager/deploy.py
+++ b/sigsci_site_manager/deploy.py
@@ -3,20 +3,15 @@ import json
 
 def create_site(api, site_name, data, display_name):
     # Create new site
-    # Not currently supported by pysigsci
-    # POST /corps/{corpName}/sites
     if not display_name:
         display_name = site_name
     print("Creating site '%s' (%s)..." % (display_name, site_name))
     data['name'] = site_name
     data['displayName'] = display_name
-    resp = api._make_request(
-        endpoint="{}/{}/sites".format(api.ep_corps, api.corp),
-        json=data,
-        method="POST_JSON"
-    )
-    if 'message' in resp:
-        print('Error: %s' % resp['message'])
+    try:
+        api.create_corp_site(data)
+    except Exception as e:
+        print('Error: %s' % e)
         return False
     return True
 

--- a/sigsci_site_manager/site_manager.py
+++ b/sigsci_site_manager/site_manager.py
@@ -22,12 +22,14 @@ def do_list(args):
 
 
 def do_deploy(args):
-    api = init_api(args.username, args.password, args.token, args.corp)
+    api = init_api(args.username, args.password, args.token, args.corp,
+                   args.dry_run)
     deploy(api, args.site_name, args.file_name, args.display_name)
 
 
 def do_clone(args):
-    api = init_api(args.username, args.password, args.token, args.corp)
+    api = init_api(args.username, args.password, args.token, args.corp,
+                   args.dry_run)
     clone(api, args.src_site, args.dst_site, args.display_name)
 
 
@@ -37,7 +39,8 @@ def do_backup(args):
 
 
 def do_merge(args):
-    api = init_api(args.username, args.password, args.token, args.corp)
+    api = init_api(args.username, args.password, args.token, args.corp,
+                   args.dry_run)
     merge(api, args.dst_site, args.src_site, args.file_name)
 
 
@@ -81,6 +84,9 @@ def get_args():
     deploy_parser.add_argument('--file', '-f', metavar='FILENAME',
                                required=True, dest='file_name',
                                help='Name of site file')
+    deploy_parser.add_argument('--dry-run', required=False,
+                               action='store_true', dest='dry_run',
+                               help='Print actions without making any changes')
 
     # Backup command arguments
     backup_parser = subparsers.add_parser('backup',
@@ -103,6 +109,9 @@ def get_args():
     clone_parser.add_argument('--display-name', '-N',
                               metavar='"Display Name"', dest='display_name',
                               help='Display name of the new site')
+    clone_parser.add_argument('--dry-run', required=False,
+                              action='store_true', dest='dry_run',
+                              help='Print actions without making any changes')
 
     # Merge command arguments
     merge_parser = subparsers.add_parser(
@@ -116,6 +125,9 @@ def get_args():
     merge_src_group.add_argument('--file', '-f', metavar='FILENAME',
                                  dest='file_name',
                                  help='Name of site file to merge from')
+    merge_parser.add_argument('--dry-run', required=False,
+                              action='store_true', dest='dry_run',
+                              help='Print actions without making any changes')
 
     # Return the parsed arguments
     return parser.parse_args()

--- a/sigsci_site_manager/util.py
+++ b/sigsci_site_manager/util.py
@@ -1,6 +1,3 @@
-import json
-
-
 def filter_data(data, keys):
     if isinstance(data, (list, tuple)):
         ret = []


### PR DESCRIPTION
- When doing a dry run none of the API calls that would make changes do
anything. The API calls that retrieve things still work.
- Update README.md for new CLI flags
- Bump the required pysigsci version and use the new create_corp_site()
method.
- Remove unused import in util.py

Fixes #6 