### PR TITLE
Update deploy/merge to add corp users, if necessary

### DIFF
--- a/sigsci_site_manager/api.py
+++ b/sigsci_site_manager/api.py
@@ -5,10 +5,25 @@ def noop(*args, **kwargs):
     return
 
 
+def update_corp_user(self, email, data):
+    """
+    Update user in corp
+    PUT /corps/{corpName}/users/{userEmail}
+    """
+    return self._make_request(
+        endpoint="{}/{}/users/{}".format(
+            self.ep_corps, self.corp, email),
+        json=data,
+        method="PUT")
+
+
 def init_api(username, password, token, corp, dry_run=False):
     api = sigsciapi.SigSciApi(
         email=username, password=password, api_token=token)
     api.corp = corp
+
+    # Work around missing functionality in pysigsci
+    setattr(sigsciapi.SigSciApi, 'update_corp_user', update_corp_user)
 
     if dry_run:
         # When doing a dry run override the API methods that make changes so
@@ -27,5 +42,7 @@ def init_api(username, password, token, corp, dry_run=False):
         api.update_site_member = noop
         api.add_integration = noop
         api.update_integration = noop
+        api.add_corp_user = noop
+        api.update_corp_user = noop
 
     return api

--- a/sigsci_site_manager/util.py
+++ b/sigsci_site_manager/util.py
@@ -121,3 +121,31 @@ def build_category_list(include: list = None, exclude: list = None):
     elif exclude:
         categories -= set(exclude)
     return categories
+
+
+def add_new_user(api, email, role, api_user):
+    # Build the user data structure
+    corp_role = 'corpUser'
+    if role == 'observer':
+        corp_role = 'corpObserver'
+    elif role == 'admin':
+        corp_role = 'corpAdmin'
+    data = {
+        'email': email,
+        'memberships': {
+            'data': [{
+                'site': {
+                    'name': api.site
+                }
+            }]
+        },
+        'role': corp_role,
+        'apiUser': api_user
+    }
+
+    api.add_corp_user(email, data)
+
+    if api_user:
+        # API users can't be added as API users directly so update
+        # after adding to enable API
+        api.update_corp_user(email, data)

--- a/tests/test_include_exclude.py
+++ b/tests/test_include_exclude.py
@@ -17,6 +17,12 @@ class DummyAPI(object):
     def create_corp_site(self, *args, **kwargs):
         return
 
+    def get_corp_users(self, *args, **kwargs):
+        return {'data': [{'email': 'test@test.com', 'apiUser': False}]}
+
+    def add_corp_user(self, *args, **kwargs):
+        return
+
 
 API = DummyAPI()
 
@@ -27,7 +33,10 @@ DATA = {
     'signal_rules': [],
     'templated_rules': [],
     'custom_alerts': [],
-    'site_members': [{'user': {'email': ''}, 'role': ''}],
+    'site_members': [{
+        'user': {'email': 'test@test.com', 'apiUser': False},
+        'role': ''
+    }],
     'integrations': [],
     'source': {'corp': 'dummy', 'site': 'dummy_src'},
     'advanced_rules': [],


### PR DESCRIPTION
If a user that needs to be added to the site does not exist in the corp
invite that user. The corp role will match the site role except in the
case of owner. The API user state is also preserved for the new user.